### PR TITLE
Add open-files route

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -519,6 +519,27 @@ paths:
         Open the specified document in Obsidian
       tags:
         - "Open"
+  /workspace/open-files:
+    get:
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                properties:
+                  open:
+                    items:
+                      type: "string"
+                    type: "array"
+                  active:
+                    nullable: true
+                    type: "string"
+                type: "object"
+          description: "Success"
+      summary: |
+        List files currently open in the workspace.
+      tags:
+        - "Workspace"
   "/periodic/{period}/":
     delete:
       description: |

--- a/mocks/obsidian.ts
+++ b/mocks/obsidian.ts
@@ -116,6 +116,20 @@ export class MetadataCache {
   }
 }
 
+export class WorkspaceLeaf {
+  view: any;
+  constructor(view: any = null) {
+    this.view = view;
+  }
+}
+
+export class MarkdownView {
+  file: TFile | null;
+  constructor(file: TFile | null = null) {
+    this.file = file;
+  }
+}
+
 export class Workspace {
   async openLinkText(
     path: string,
@@ -125,8 +139,17 @@ export class Workspace {
     return new Promise((resolve, reject) => resolve());
   }
 
-  getActiveFile(): TFile {
-    return new TFile();
+  leaves: WorkspaceLeaf[] = [];
+  _activeFile: TFile | null = null;
+
+  getActiveFile(): TFile | null {
+    return this._activeFile;
+  }
+
+  iterateAllLeaves(callback: (leaf: WorkspaceLeaf) => any): void {
+    for (const leaf of this.leaves) {
+      callback(leaf);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- implement `GET /workspace/open-files` to list open files and the active file
- support mocks and tests for the new route
- document the new endpoint in OpenAPI spec

## Testing
- `npm test`
- `npm run build`