### PR TITLE
Fix open-files route to include deferred leaves

### DIFF
--- a/mocks/obsidian.ts
+++ b/mocks/obsidian.ts
@@ -118,8 +118,18 @@ export class MetadataCache {
 
 export class WorkspaceLeaf {
   view: any;
-  constructor(view: any = null) {
+  _viewState: { type: string; state: Record<string, unknown> } | null;
+  constructor(view: any = null, viewState: { type: string; state: Record<string, unknown> } | null = null) {
     this.view = view;
+    this._viewState = viewState;
+  }
+
+  getViewState(): { type: string; state: Record<string, unknown> } {
+    if (this._viewState) {
+      return this._viewState;
+    }
+    const file = (this.view as any)?.file;
+    return { type: "markdown", state: file ? { file: file.path ?? file } : {} };
   }
 }
 

--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -1132,18 +1132,18 @@ export default class RequestHandler {
     req: express.Request,
     res: express.Response
   ): Promise<void> {
-    const open: string[] = [];
+    const open = new Set<string>();
 
     this.app.workspace.iterateAllLeaves((leaf: WorkspaceLeaf) => {
-      const tfile = (leaf.view as MarkdownView | { file?: TFile }).file;
-      if (tfile) {
-        open.push(tfile.path);
+      const { type, state } = leaf.getViewState();
+      if (type === "markdown" && typeof (state as any)?.file === "string") {
+        open.add((state as any).file);
       }
     });
 
     const active = this.app.workspace.getActiveFile()?.path ?? null;
 
-    res.json({ open, active });
+    res.json({ open: Array.from(open), active });
   }
 
   async certificateGet(


### PR DESCRIPTION
## Summary
- ensure `openFilesGet` checks view state instead of view
- provide `getViewState` in mocks for `WorkspaceLeaf`

## Testing
- `npm test`
- `npm run build`
